### PR TITLE
Add consulting services page

### DIFF
--- a/index.md
+++ b/index.md
@@ -12,4 +12,4 @@ I'm Lina L. Faller, a computational biologist passionate about data democratizat
 - [{{ post.title }}]({{ post.url }}) - {{ post.date | date: "%B %d, %Y" }}
 {% endfor %}
 
-[About me](about) | [All posts](blog)
+[About me](about) | [All posts](blog) | [Work With Me](services)

--- a/services.md
+++ b/services.md
@@ -1,0 +1,41 @@
+---
+layout: page
+title: Work With Me
+permalink: /services/
+---
+
+# Work With Me
+
+## Remove Data Bottlenecks in Your Biotech
+
+I help biotech companies remove data bottlenecks by building self-service tools that get scientists to actionable insights in minutes instead of days, without relying on overworked data scientists.
+
+### The Problem I Solve
+
+Your scientists are brilliant, but they're stuck waiting days or weeks for data analysis. Your data team is overwhelmed with ad-hoc requests, and critical decisions are delayed while insights sit locked in databases.
+
+### What I Offer
+
+I build intuitive self-service platforms that empower your scientists to:
+- Access and explore complex datasets independently
+- Generate insights without writing code
+- Make faster, data-driven decisions
+- Free up your data science team to focus on strategic work
+
+### My Approach
+
+With 10+ years of experience at the intersection of software engineering and life sciences, I specialize in:
+- **Data democratization:** Creating tools that make complex genomic and multi-omics data accessible to non-technical scientists
+- **Scalable architecture:** Building cloud-based data pipelines that grow with your needs
+- **User-centered design:** Developing interfaces that scientists actually want to use
+- **Cross-functional collaboration:** Bridging the gap between computational and biological teams
+
+### Results
+
+When scientists have frictionless access to their data, breakthroughs happen faster. I transform manual, bottlenecked processes into automated, self-service solutions that accelerate scientific discovery.
+
+### Let's Talk
+
+Ready to unlock your team's productivity? Let's discuss how I can help remove your data bottlenecks.
+
+**Contact:** [LinkedIn](https://linkedin.com/in/linafaller)


### PR DESCRIPTION
## Summary
- Added new "Work With Me" services page highlighting consulting offerings for biotech companies
- Added navigation link in homepage to make services easily discoverable
- Created clear UVP focused on removing data bottlenecks and enabling self-service insights

## Test plan
- [ ] Verify the services page renders correctly at `/services/`
- [ ] Check that the "Work With Me" navigation link appears on the homepage
- [ ] Confirm all links work properly (navigation and LinkedIn contact)
- [ ] Review content and messaging for clarity and alignment with brand voice

🤖 Generated with [Claude Code](https://claude.com/claude-code)