### PR TITLE
Add Calendly booking link to services page

### DIFF
--- a/services.md
+++ b/services.md
@@ -38,4 +38,4 @@ When scientists have frictionless access to their data, breakthroughs happen fas
 
 Ready to unlock your team's productivity? Let's discuss how I can help remove your data bottlenecks.
 
-**Contact:** [LinkedIn](https://linkedin.com/in/linafaller)
+[Schedule a 30-minute consultation](https://calendly.com/lina-l-faller/30min) or connect with me on [LinkedIn](https://linkedin.com/in/linafaller)


### PR DESCRIPTION
## Summary
- Added Calendly link to "Let's Talk" section for direct consultation booking
- Replaced generic "Contact" label with clear call-to-action to schedule a 30-minute consultation

## Test plan
- [ ] Verify the Calendly link works and directs to the correct booking page
- [ ] Confirm the LinkedIn link still functions properly
- [ ] Check that the formatting and messaging flow naturally

🤖 Generated with [Claude Code](https://claude.com/claude-code)