### PR TITLE
Add LinkedIn-Jekyll cross-posting automation

### DIFF
--- a/.github/workflows/linkedin-crosspost.yml
+++ b/.github/workflows/linkedin-crosspost.yml
@@ -1,0 +1,53 @@
+name: Cross-post to LinkedIn
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - '_posts/**'
+  workflow_dispatch:
+
+jobs:
+  crosspost:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2  # Need to compare with previous commit
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          cd scripts
+          pip install -r requirements.txt
+
+      - name: Get new or modified posts
+        id: changed-files
+        run: |
+          # Get list of added or modified markdown files in _posts/
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            # Manual trigger: get the most recent post
+            LATEST_POST=$(ls -t _posts/*.md | head -n 1)
+            echo "posts=$LATEST_POST" >> $GITHUB_OUTPUT
+          else
+            # Automatic trigger: get changed files
+            CHANGED_FILES=$(git diff --name-only HEAD^ HEAD -- _posts/*.md | tr '\n' ' ')
+            echo "posts=$CHANGED_FILES" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Cross-post to LinkedIn
+        if: steps.changed-files.outputs.posts != ''
+        env:
+          LINKEDIN_ACCESS_TOKEN: ${{ secrets.LINKEDIN_ACCESS_TOKEN }}
+          LINKEDIN_AUTHOR_ID: ${{ secrets.LINKEDIN_AUTHOR_ID }}
+        run: |
+          cd scripts
+          for POST in ${{ steps.changed-files.outputs.posts }}; do
+            echo "Processing: $POST"
+            python linkedin_post.py "../$POST"
+          done

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,16 @@ _site/
 node_modules/
 vendor/
 
+# Python virtual environments
+venv/
+env/
+scripts/venv/
+
+# Python cache
+__pycache__/
+*.pyc
+*.pyo
+
 # Bundler
 .bundle/
 Gemfile.lock
@@ -36,4 +46,5 @@ Thumbs.db
 
 # Local environment files
 .env
-.env.local_site/
+.env.local
+scripts/.env_site/

--- a/PROJECT_BRIEF.md
+++ b/PROJECT_BRIEF.md
@@ -1,0 +1,248 @@
+# LinkedIn-Jekyll Cross-Posting Automation Project
+
+## Project Overview
+Automate the posting workflow for content that currently goes to both LinkedIn (1-2x per week) and personal website (linafaller.com, a Jekyll site hosted on GitHub Pages).
+
+## Current Manual Process
+1. Write post content
+2. Post to LinkedIn with:
+   - Hashtags (e.g., #datascience)
+   - Picture/image
+   - Unicode formatted text
+3. Post to Jekyll website with:
+   - Same content in Markdown format
+   - Frontmatter (YAML header)
+   - Category tags (e.g., "data-science" or "software-engineering")
+   - NO hashtags
+   - Same picture/image
+
+## Problem
+Doing this manually for each post is tedious and error-prone. Need automation.
+
+## Research Findings
+
+### LinkedIn API Capabilities
+- **Official API exists**: LinkedIn provides OAuth 2.0 authenticated API endpoints
+- **Personal profile posting**: Supported via `w_member_social` scope
+- **Rate limits**: 25 posts per 24-hour period for personal profiles (more than sufficient for 1-2/week)
+- **Token expiration**: Access tokens expire after 60 days, requiring refresh
+- **Setup requirements**: 
+  - Must create LinkedIn Developer App
+  - Requires association with a LinkedIn Company Page (even for personal posting)
+  - Need to verify the app
+  - Request "Share on LinkedIn" product access
+
+### Existing Solutions Evaluated
+1. **IFTTT/Zapier**: Too limited - can only share article links, not full text posts with custom formatting
+2. **n8n**: More flexible open-source automation, but overkill for this simple use case
+3. **Jekyll social plugins**: Focus on RSS-based sharing, don't handle the markdown→unicode conversion or hashtag logic
+
+### Decision: Custom Python Script
+**Why custom code wins:**
+- Full control over markdown→unicode conversion
+- Handle hashtag removal/addition logic
+- Category mapping between platforms
+- Bidirectional workflow options
+- Only needed for 1-2 posts/week (simple requirements)
+
+## Implementation Plan
+
+### Repository Structure
+**Decision**: Keep in existing website repo (https://github.com/lfaller/lfaller.github.io)
+**Reasoning**: 
+- Natural coupling with _posts/ directory
+- Simpler workflow
+- Easier path management
+- No cross-repo complexity needed
+
+### Proposed Directory Structure
+```
+lfaller.github.io/
+├── _posts/                    # Existing Jekyll posts
+├── _config.yml               # Existing Jekyll config
+├── scripts/                  # NEW - Automation scripts
+│   ├── cross_poster.py       # Main posting script
+│   ├── requirements.txt      # Python dependencies
+│   ├── .env.example          # Template for credentials
+│   └── README.md             # Usage documentation
+├── .gitignore               # Update to exclude .env
+└── ... (rest of Jekyll site)
+```
+
+### Technical Architecture
+
+#### Option A: LinkedIn → Jekyll (Recommended)
+**Workflow:**
+1. Write post in simple text/markdown file or interactive prompt
+2. Python script posts to LinkedIn (with hashtags, unicode formatting)
+3. Same script creates Jekyll post (markdown, frontmatter, no hashtags)
+4. Optionally auto-commit to Git
+
+#### Option B: Jekyll → LinkedIn
+**Workflow:**
+1. Create Jekyll post with special frontmatter fields for LinkedIn
+2. Script detects new post (Git hook or manual trigger)
+3. Converts markdown to plain text/unicode
+4. Adds hashtags from frontmatter
+5. Posts to LinkedIn
+
+**Recommendation**: Start with Option A (LinkedIn first) as it's simpler and matches current mental workflow.
+
+### Core Script Components
+
+```python
+# Pseudo-code structure
+class CrossPoster:
+    def __init__(self, access_token, author_id):
+        """Initialize with LinkedIn credentials"""
+        
+    def post_to_linkedin(self, text, image_path=None, hashtags=[]):
+        """
+        - Convert markdown to plain text
+        - Add hashtags at end
+        - Upload image if provided
+        - Make API POST request
+        - Return LinkedIn post URL
+        """
+        
+    def create_jekyll_post(self, title, content, category, image_path=None):
+        """
+        - Generate frontmatter with date, title, categories
+        - Remove hashtags from content
+        - Keep markdown formatting
+        - Save to _posts/ with proper naming (YYYY-MM-DD-title.md)
+        """
+        
+    def cross_post(self, title, content, category, image_path, hashtags):
+        """
+        - Post to LinkedIn first
+        - Create Jekyll post
+        - Return both URLs/paths
+        """
+```
+
+### Required Python Libraries
+- `requests` - LinkedIn API calls
+- `python-frontmatter` - Jekyll YAML frontmatter handling
+- `python-dotenv` - Environment variable management
+- `Pillow` (optional) - Image processing if needed
+- `markdown` (optional) - Markdown to HTML/text conversion
+
+### LinkedIn API Setup Steps
+1. Go to LinkedIn Developer Portal
+2. Create new app
+3. Create/associate LinkedIn Company Page (requirement)
+4. Request "Share on LinkedIn" product access
+5. Verify app in settings
+6. Get Client ID and Client Secret
+7. Generate OAuth 2.0 access token with scopes: `openid`, `profile`, `w_member_social`
+8. Get your LinkedIn author ID (via API call to `/v2/userinfo`)
+9. Store credentials securely in .env file
+
+### Security Considerations
+- **Never commit credentials**: Add `.env` to `.gitignore`
+- **Token storage**: Use environment variables
+- **Token refresh**: Build in 60-day token refresh reminder/automation
+- **API rate limits**: Built-in checks to stay under 25/day
+
+### Content Format Mappings
+
+#### LinkedIn Format
+- Plain text or unicode formatting
+- Hashtags included (#datascience #machinelearning)
+- Images attached via API
+- Emojis and unicode characters allowed
+
+#### Jekyll Format
+```yaml
+---
+layout: post
+title: "Post Title Here"
+date: 2025-11-08 14:30:00 -0500
+categories: [data-science]
+image: /assets/images/2025-11-08-post-image.jpg
+---
+
+Post content here in Markdown format.
+No hashtags included.
+```
+
+## Next Steps for Implementation
+
+1. **Setup Phase**:
+   - Create `scripts/` directory in lfaller.github.io repo
+   - Set up LinkedIn Developer App
+   - Obtain API credentials
+   - Create `.env.example` template
+
+2. **Core Development**:
+   - Write `cross_poster.py` with basic functionality
+   - Implement LinkedIn API authentication
+   - Build post creation functions
+   - Add image handling
+
+3. **Testing**:
+   - Test with sample posts (not published)
+   - Verify markdown→plain text conversion
+   - Test Jekyll file creation with proper frontmatter
+   - Validate image uploads
+
+4. **Documentation**:
+   - Write README with usage instructions
+   - Document credential setup
+   - Add example commands
+
+5. **Enhancement** (Optional Future):
+   - Add CLI arguments for easier use
+   - Build interactive prompt mode
+   - Add draft/scheduled posting
+   - GitHub Actions integration
+
+## Key Technical Details from Research
+
+### LinkedIn API Endpoints
+- Authentication: `https://www.linkedin.com/oauth/v2/authorization`
+- Token exchange: `https://www.linkedin.com/oauth/v2/accessToken`
+- Get author ID: `https://api.linkedin.com/v2/userinfo`
+- Post creation: `https://api.linkedin.com/v2/ugcPosts` (older API) or `https://api.linkedin.com/rest/posts` (newer)
+- Required headers: `Authorization: Bearer {token}`, `Content-Type: application/json`
+
+### Sample LinkedIn API Post Request
+```json
+{
+  "author": "urn:li:person:{AUTHOR_ID}",
+  "lifecycleState": "PUBLISHED",
+  "specificContent": {
+    "com.linkedin.ugc.ShareContent": {
+      "shareCommentary": {
+        "text": "Post content here #hashtag"
+      },
+      "shareMediaCategory": "NONE"
+    }
+  },
+  "visibility": {
+    "com.linkedin.ugc.MemberNetworkVisibility": "PUBLIC"
+  }
+}
+```
+
+## Questions to Resolve During Development
+1. How to handle image uploads to LinkedIn API?
+2. Should we store post history/mapping between LinkedIn and Jekyll?
+3. Interactive mode vs. file-based input?
+4. Auto-commit to Git or leave manual?
+5. Error handling for API failures?
+
+## Success Criteria
+- Can post to LinkedIn and create Jekyll file with single command
+- Proper hashtag handling (included on LinkedIn, removed from Jekyll)
+- Correct markdown/unicode conversion
+- Images properly handled on both platforms
+- Credentials stored securely
+- Simple enough to use regularly (1-2x per week)
+
+## References
+- GitHub Repo: https://github.com/lfaller/lfaller.github.io
+- Website: https://linafaller.com
+- LinkedIn Developer Portal: https://www.linkedin.com/developers/
+- Jekyll Documentation: https://jekyllrb.com/docs/posts/

--- a/_posts/2025-11-08-my-first-auto-post.md
+++ b/_posts/2025-11-08-my-first-auto-post.md
@@ -1,0 +1,16 @@
+---
+layout: post
+author: lina
+title:  "My First Auto Post"
+date:   2025-11-08 07:41:50 
+categories: data-science
+---
+
+This is an example markdown file showing how to format your content for cross-posting.
+You can use **bold text**, *italic text*, and even `code snippets` in your markdown.
+Here are some important insights:
+- Data science is evolving rapidly
+- Machine learning models require careful validation
+- Always document your methodology
+You can include [links like this](https://example.com) and they'll be properly formatted for each platform.
+This content will be automatically converted to the right format for LinkedIn (plain text with hashtags) and Jekyll (clean markdown without hashtags).

--- a/scripts/.env.example
+++ b/scripts/.env.example
@@ -1,0 +1,23 @@
+# LinkedIn API Credentials
+# DO NOT commit the actual .env file - keep credentials secure!
+
+# LinkedIn OAuth 2.0 Access Token
+# Get this from: https://www.linkedin.com/developers/apps
+# Required scopes: openid, profile, w_member_social
+# Note: Tokens expire after 60 days
+LINKEDIN_ACCESS_TOKEN=your_access_token_here
+
+# LinkedIn Author ID (your person URN)
+# Get this from API call to: https://api.linkedin.com/v2/userinfo
+# Format: urn:li:person:XXXXXXXXXX
+LINKEDIN_AUTHOR_ID=urn:li:person:your_id_here
+
+# Optional: LinkedIn App Credentials (for token refresh)
+LINKEDIN_CLIENT_ID=your_client_id_here
+LINKEDIN_CLIENT_SECRET=your_client_secret_here
+
+# Jekyll Posts Directory (relative to repo root)
+JEKYLL_POSTS_DIR=_posts
+
+# Jekyll Assets Directory (for images, relative to repo root)
+JEKYLL_ASSETS_DIR=assets/images

--- a/scripts/LINKEDIN_SETUP.md
+++ b/scripts/LINKEDIN_SETUP.md
@@ -1,0 +1,164 @@
+# LinkedIn API Setup Guide
+
+This document covers the setup process for LinkedIn API integration, including common issues encountered.
+
+## Prerequisites
+
+1. LinkedIn Developer account
+2. A LinkedIn app with posting permissions
+
+## Creating a LinkedIn App
+
+1. Go to [LinkedIn Developer Portal](https://www.linkedin.com/developers/apps)
+2. Click **"Create app"**
+3. Fill in the required information:
+   - App name
+   - LinkedIn Page (you can use your personal profile page)
+   - App logo (optional)
+4. Click **"Create app"**
+
+## Required Products & Scopes
+
+### Step 1: Add Required Products
+
+In your app settings, go to the **Products** tab and add:
+
+1. **"Share on LinkedIn"** - For posting content
+2. **"Sign In with LinkedIn using OpenID Connect"** - For retrieving your member ID
+
+### Step 2: Configure OAuth Scopes
+
+After adding the products, verify you have these scopes in the **Auth** tab:
+
+- ✅ `openid` - Required for OpenID Connect
+- ✅ `profile` - Required to get your numeric member ID
+- ✅ `w_member_social` - Required for posting content
+
+## Getting Your Credentials
+
+### 1. Get OAuth Access Token
+
+1. In your app, go to the **Auth** tab
+2. Scroll to **OAuth 2.0 tools**
+3. Click **"Create token"** or **"Generate token"**
+4. **IMPORTANT**: Make sure all three scopes are checked:
+   - `openid`
+   - `profile`
+   - `w_member_social`
+5. Copy the access token
+
+**Note**: Access tokens expire after 60 days. You'll need to regenerate periodically.
+
+### 2. Get Your Member ID
+
+Run the helper script with your new access token:
+
+```bash
+cd scripts
+source venv/bin/activate
+python get_author_id.py YOUR_ACCESS_TOKEN
+```
+
+Or use curl:
+
+```bash
+curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
+     https://api.linkedin.com/v2/userinfo
+```
+
+The response will include your `sub` field, which is your numeric member ID:
+
+```json
+{
+  "sub": "123456789",
+  "name": "Your Name",
+  "email": "your@email.com"
+}
+```
+
+Your author ID will be: `urn:li:member:123456789`
+
+## Common Issues
+
+### Issue 1: 403 Error on `/v2/userinfo`
+
+**Error**: `"Not enough permissions to access: userinfo.GET.NO_VERSION"`
+
+**Cause**: Your access token doesn't have the `openid` and `profile` scopes.
+
+**Solution**:
+1. Add the "Sign In with LinkedIn using OpenID Connect" product to your app
+2. Generate a **NEW** access token with `openid`, `profile`, and `w_member_social` scopes
+3. The old token won't automatically get new scopes - you must regenerate
+
+### Issue 2: 422 Error on Posting
+
+**Error**: `"urn:li:person:XXX" does not match urn:li:member:\\d+`
+
+**Cause**: Wrong URN format. LinkedIn's posting API requires:
+- ✅ `urn:li:member:123456` (numeric ID)
+- ❌ `urn:li:person:ACoAAAERPDo...` (alphanumeric profile ID)
+
+**Solution**: Use the `get_author_id.py` script with a token that has `profile` scope to get the correct numeric ID.
+
+### Issue 3: Alphanumeric vs Numeric IDs
+
+LinkedIn has multiple ID formats:
+- **Profile URN**: `urn:li:fsd_profile:ACoAAAERPDo...` (from web interface)
+- **Person URN**: `urn:li:person:ACoAAAERPDo...` (from Voyager API)
+- **Member URN**: `urn:li:member:123456` (from REST API - **this is what you need**)
+
+Only the numeric member URN works with the posting API.
+
+### Issue 4: Scope Authorization Delays
+
+**Symptom**: Just added OpenID Connect product but still getting 403 errors
+
+**Solution**: Wait a few minutes for LinkedIn to process the authorization on their backend. If it persists beyond 10 minutes, try:
+1. Regenerating your access token
+2. Logging out and back into LinkedIn Developer Portal
+3. Checking that the products show as "Active" in your app settings
+
+## Setting Up GitHub Actions
+
+Once you have your credentials:
+
+1. Go to your GitHub repository
+2. Navigate to: **Settings → Secrets and variables → Actions**
+3. Click **"New repository secret"**
+4. Add two secrets:
+   - Name: `LINKEDIN_ACCESS_TOKEN`, Value: Your OAuth token
+   - Name: `LINKEDIN_AUTHOR_ID`, Value: `urn:li:member:YOUR_NUMERIC_ID`
+
+The GitHub Action will use these secrets to post to LinkedIn automatically when you push to main.
+
+## Testing Your Setup
+
+Test that everything works:
+
+```bash
+cd scripts
+source venv/bin/activate
+
+# Test getting your author ID
+python get_author_id.py YOUR_ACCESS_TOKEN
+
+# Test posting (this will create a real post!)
+python linkedin_post.py ../_posts/your-post.md
+```
+
+## Access Token Expiration
+
+LinkedIn access tokens expire after **60 days**. When your token expires:
+
+1. Go to LinkedIn Developer Portal
+2. Navigate to your app → Auth tab
+3. Generate a new token with the same scopes
+4. Update your `.env` file (local) and GitHub Secrets (for Actions)
+
+## Security Notes
+
+- Never commit your `.env` file (already in `.gitignore`)
+- Never share your access token publicly
+- Rotate tokens if accidentally exposed
+- Use GitHub Secrets for CI/CD - never hardcode credentials

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,419 @@
+# LinkedIn-Jekyll Cross-Posting Automation
+
+Automate posting content to both LinkedIn and your Jekyll website. This tool handles format conversion, hashtag management, and image uploads.
+
+## Features
+
+- **GitHub Actions Integration**: Automatically post to LinkedIn when you push to main
+- Post to LinkedIn and Jekyll simultaneously (manual mode)
+- Automatic markdown to plain text conversion for LinkedIn
+- Smart hashtag handling (included on LinkedIn, removed from Jekyll)
+- Image upload support for both platforms
+- Category-based post organization
+- Secure credential management
+- CLI interface for easy use
+
+## Automated Workflow (Recommended)
+
+The easiest way to use this tool is via GitHub Actions:
+
+1. Write your Jekyll post in `_posts/` with frontmatter
+2. Commit and push to the `main` branch
+3. GitHub Actions automatically:
+   - Deploys to GitHub Pages
+   - Posts to LinkedIn with proper formatting
+
+### Setup GitHub Actions
+
+1. Go to your repository Settings → Secrets and variables → Actions
+2. Add the following secrets:
+   - `LINKEDIN_ACCESS_TOKEN`: Your LinkedIn OAuth token
+   - `LINKEDIN_AUTHOR_ID`: Your LinkedIn member URN (format: `urn:li:member:123456`)
+
+The workflow will automatically trigger when you push changes to `_posts/` directory.
+
+## Manual Usage
+
+## Setup
+
+### 1. Install Python Dependencies
+
+**Option A: Quick Setup (Recommended)**
+
+Run the automated setup script:
+
+```bash
+cd scripts
+./setup.sh
+```
+
+This will create a virtual environment, install all dependencies, and provide next steps.
+
+**Option B: Manual Setup**
+
+```bash
+cd scripts
+
+# Create virtual environment
+python3 -m venv venv
+
+# Activate virtual environment
+source venv/bin/activate  # On Windows: venv\Scripts\activate
+
+# Install dependencies
+pip install -r requirements.txt
+```
+
+**Important:** Always activate the virtual environment before using the cross-poster:
+```bash
+cd scripts
+source venv/bin/activate  # You'll see (venv) in your prompt
+```
+
+To deactivate when done:
+```bash
+deactivate
+```
+
+### 2. Configure LinkedIn API Access
+
+#### Create a LinkedIn Developer App
+
+1. Go to [LinkedIn Developer Portal](https://www.linkedin.com/developers/apps)
+2. Click "Create app"
+3. Fill in the required information:
+   - App name: "Personal Blog Cross-Poster" (or your choice)
+   - LinkedIn Page: You must create/associate a LinkedIn Company Page
+   - App logo (optional)
+4. After creation, go to the "Products" tab
+5. Request access to "Share on LinkedIn" product
+6. Wait for approval (usually instant for verified apps)
+
+#### Get Your Credentials
+
+1. Go to the "Auth" tab in your app
+2. Copy your **Client ID** and **Client Secret**
+3. Add `http://localhost:8000/callback` to "Redirect URLs" (for local OAuth flow)
+
+#### Generate an Access Token
+
+You need to generate an OAuth 2.0 access token with the following scopes:
+- `openid`
+- `profile`
+- `w_member_social`
+
+**Option A: Use LinkedIn's OAuth Playground** (Easiest)
+1. Use a tool like [LinkedIn OAuth Token Generator](https://www.linkedin.com/developers/tools/oauth)
+2. Select the required scopes
+3. Authorize and copy the access token
+
+**Option B: Manual OAuth Flow**
+1. Construct authorization URL:
+```
+https://www.linkedin.com/oauth/v2/authorization?response_type=code&client_id=YOUR_CLIENT_ID&redirect_uri=http://localhost:8000/callback&scope=openid%20profile%20w_member_social
+```
+2. Visit the URL in a browser and authorize
+3. Copy the `code` from the redirect URL
+4. Exchange code for token:
+```bash
+curl -X POST https://www.linkedin.com/oauth/v2/accessToken \
+  -d grant_type=authorization_code \
+  -d code=YOUR_AUTH_CODE \
+  -d client_id=YOUR_CLIENT_ID \
+  -d client_secret=YOUR_CLIENT_SECRET \
+  -d redirect_uri=http://localhost:8000/callback
+```
+
+#### Get Your LinkedIn Author ID
+
+```bash
+curl -X GET https://api.linkedin.com/v2/userinfo \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+```
+
+The response will include your `sub` field - this is your author ID. Convert it to URN format: `urn:li:person:YOUR_SUB_VALUE`
+
+### 3. Configure Environment Variables
+
+1. Copy the example environment file:
+```bash
+cp .env.example .env
+```
+
+2. Edit `.env` and fill in your credentials:
+```bash
+# Required
+LINKEDIN_ACCESS_TOKEN=your_access_token_here
+LINKEDIN_AUTHOR_ID=urn:li:person:your_id_here
+
+# Optional (for token refresh)
+LINKEDIN_CLIENT_ID=your_client_id_here
+LINKEDIN_CLIENT_SECRET=your_client_secret_here
+```
+
+**Important:** Never commit your `.env` file to Git. It's already included in `.gitignore`.
+
+## Usage
+
+### Basic Examples
+
+#### Post to both LinkedIn and Jekyll:
+
+```bash
+python cross_poster.py \
+  --title "My First Post" \
+  --content "This is my post content with **markdown** formatting." \
+  --category data-science \
+  --hashtags datascience machinelearning ai
+```
+
+#### Post from a markdown file:
+
+```bash
+python cross_poster.py \
+  --title "Advanced ML Techniques" \
+  --file my-draft.md \
+  --category data-science \
+  --image ./images/ml-diagram.png \
+  --hashtags machinelearning deeplearning
+```
+
+#### Post to LinkedIn only:
+
+```bash
+python cross_poster.py \
+  --title "Quick LinkedIn Update" \
+  --content "Check out this insight!" \
+  --category software-engineering \
+  --hashtags coding \
+  --linkedin-only
+```
+
+#### Create Jekyll post only:
+
+```bash
+python cross_poster.py \
+  --title "Blog Post" \
+  --file post-draft.md \
+  --category leadership \
+  --image header.jpg \
+  --jekyll-only
+```
+
+### Command-Line Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `--title` | Yes | Post title |
+| `--content` | Either this or `--file` | Post content as string |
+| `--file` | Either this or `--content` | Path to markdown file with content |
+| `--category` | Yes | Jekyll category: `data-science`, `software-engineering`, `career`, or `leadership` |
+| `--image` | No | Path to image file (will be uploaded to both platforms) |
+| `--hashtags` | No | Space-separated hashtags for LinkedIn (without `#`) |
+| `--linkedin-only` | No | Only post to LinkedIn, skip Jekyll |
+| `--jekyll-only` | No | Only create Jekyll post, skip LinkedIn |
+
+### Example Workflow
+
+1. **Write your content in a markdown file:**
+
+```markdown
+# My Post Title
+
+This is the introduction with **bold text** and *italics*.
+
+Here's a key insight about data science...
+
+## Key Points
+
+- Point one
+- Point two
+- Point three
+```
+
+2. **Prepare your image (optional):**
+   - Save it in a convenient location
+   - Recommended: 1200x630px for optimal LinkedIn display
+
+3. **Run the cross-poster:**
+
+```bash
+python cross_poster.py \
+  --title "My Post Title" \
+  --file draft.md \
+  --category data-science \
+  --image post-image.jpg \
+  --hashtags datascience analytics insights
+```
+
+4. **Review the output:**
+   - LinkedIn post URL (if successful)
+   - Jekyll post file path
+   - Any errors or warnings
+
+5. **Commit and push to GitHub (for Jekyll site):**
+
+```bash
+cd ..  # Back to repo root
+git add _posts/*.md assets/images/*
+git commit -m "Add new post: My Post Title"
+git push
+```
+
+## How It Works
+
+### Format Conversion
+
+**LinkedIn:**
+- Markdown formatting is converted to plain text
+- Links `[text](url)` become `text (url)`
+- Bold/italic markers are removed
+- Hashtags are appended at the end
+
+**Jekyll:**
+- Content remains in full markdown format
+- Hashtag lines are removed
+- Frontmatter is automatically generated
+- Images are copied to `assets/images/`
+
+### Image Handling
+
+**LinkedIn:**
+- Images are uploaded via LinkedIn's Asset API
+- Registered as feed-share images
+- Attached to the post
+
+**Jekyll:**
+- Images are copied to `assets/images/YYYY-MM-DD-slug.ext`
+- Relative path is added to frontmatter
+- Referenced in post automatically
+
+### Generated Jekyll Post Format
+
+```yaml
+---
+layout: post
+title: "My Post Title"
+date: 2025-11-08 14:30:00 -0500
+categories: [data-science]
+image: /assets/images/2025-11-08-my-post-title.jpg
+---
+
+Post content here in markdown format.
+No hashtags included.
+```
+
+## Troubleshooting
+
+### "Missing LinkedIn credentials" Error
+
+Make sure you:
+1. Created a `.env` file (copy from `.env.example`)
+2. Added your `LINKEDIN_ACCESS_TOKEN` and `LINKEDIN_AUTHOR_ID`
+3. Are running the script from the `scripts/` directory or using the correct path
+
+### LinkedIn API Errors
+
+**401 Unauthorized:**
+- Your access token may have expired (tokens last 60 days)
+- Generate a new access token following the setup steps
+
+**403 Forbidden:**
+- Your app may not have "Share on LinkedIn" product access
+- Check your app's Products tab in the Developer Portal
+
+**Rate Limit Errors:**
+- LinkedIn allows 25 posts per 24 hours
+- Wait before posting again
+
+### Image Upload Failures
+
+- Check that the image file exists and path is correct
+- Ensure image is a common format (JPG, PNG)
+- Very large images may fail - try resizing to <5MB
+
+### Jekyll Post Not Created
+
+- Check that `_posts/` directory exists in your repo root
+- Verify write permissions
+- Check that category is one of the allowed values
+
+## Token Refresh
+
+LinkedIn access tokens expire after **60 days**. When your token expires:
+
+1. Follow the "Generate an Access Token" steps again
+2. Update `LINKEDIN_ACCESS_TOKEN` in your `.env` file
+3. Continue posting
+
+**Future Enhancement:** Automatic token refresh using refresh tokens (not yet implemented).
+
+## Security Best Practices
+
+- Never commit your `.env` file
+- Keep your access token secure
+- Rotate tokens periodically
+- Use environment variables, not hardcoded credentials
+- Review LinkedIn API permissions regularly
+
+## Advanced Usage
+
+### Custom Post Directory
+
+Override the default Jekyll directories in `.env`:
+
+```bash
+JEKYLL_POSTS_DIR=_posts
+JEKYLL_ASSETS_DIR=assets/images
+```
+
+### Scripting / Automation
+
+You can call the script from other scripts or automate it:
+
+```bash
+#!/bin/bash
+# Example: Post from a drafts directory
+
+for file in drafts/*.md; do
+    python scripts/cross_poster.py \
+        --title "$(basename "$file" .md)" \
+        --file "$file" \
+        --category data-science \
+        --hashtags datascience
+done
+```
+
+### Integration with Git Hooks
+
+Add to `.git/hooks/post-commit` to auto-post when committing new content:
+
+```bash
+#!/bin/bash
+# Example: Auto-post new Jekyll posts
+# (Use with caution - you may want manual control)
+
+git diff --name-only HEAD HEAD~1 | grep "^_posts/" | while read file; do
+    # Extract title and post to LinkedIn
+    # (Implementation left as exercise)
+done
+```
+
+## Contributing
+
+Found a bug or have a feature request? Please open an issue in the GitHub repository.
+
+## License
+
+This project is part of the [lfaller.github.io](https://github.com/lfaller/lfaller.github.io) repository.
+
+## Support
+
+For questions or issues:
+1. Check the troubleshooting section above
+2. Review the [LinkedIn API documentation](https://docs.microsoft.com/en-us/linkedin/)
+3. Open an issue on GitHub
+
+---
+
+**Happy posting!** 🎉

--- a/scripts/cross_poster.py
+++ b/scripts/cross_poster.py
@@ -1,0 +1,526 @@
+#!/usr/bin/env python3
+"""
+LinkedIn-Jekyll Cross-Posting Automation
+
+This script automates posting content to both LinkedIn and a Jekyll website.
+It handles format conversion, hashtag management, and image uploads.
+
+Usage:
+    python cross_poster.py --title "My Post" --content "Content here" --category data-science --hashtags datascience machinelearning
+    python cross_poster.py --file post.md --category software-engineering --image image.jpg --hashtags coding python
+
+Author: Lina Faller
+"""
+
+import os
+import sys
+import re
+import argparse
+from datetime import datetime
+from pathlib import Path
+from typing import List, Optional, Dict, Tuple
+import requests
+from dotenv import load_dotenv
+
+# Load environment variables
+load_dotenv()
+
+
+class CrossPoster:
+    """Handles cross-posting between LinkedIn and Jekyll website"""
+
+    def __init__(self, validate_credentials: bool = True):
+        """Initialize with credentials from environment variables
+
+        Args:
+            validate_credentials: If True, raise error if LinkedIn credentials missing
+        """
+        self.access_token = os.getenv('LINKEDIN_ACCESS_TOKEN')
+        self.author_id = os.getenv('LINKEDIN_AUTHOR_ID')
+        self.client_id = os.getenv('LINKEDIN_CLIENT_ID')
+        self.client_secret = os.getenv('LINKEDIN_CLIENT_SECRET')
+
+        # Directory paths (relative to repo root)
+        self.repo_root = Path(__file__).parent.parent
+        self.posts_dir = self.repo_root / os.getenv('JEKYLL_POSTS_DIR', '_posts')
+        self.assets_dir = self.repo_root / os.getenv('JEKYLL_ASSETS_DIR', 'assets/images')
+
+        # LinkedIn API endpoints
+        self.linkedin_api_base = "https://api.linkedin.com"
+        self.linkedin_post_endpoint = f"{self.linkedin_api_base}/v2/ugcPosts"
+        self.linkedin_asset_endpoint = f"{self.linkedin_api_base}/v2/assets"
+
+        # Validate credentials if requested
+        if validate_credentials and (not self.access_token or not self.author_id):
+            raise ValueError(
+                "Missing LinkedIn credentials. Please set LINKEDIN_ACCESS_TOKEN and "
+                "LINKEDIN_AUTHOR_ID in your .env file."
+            )
+
+    def _get_headers(self) -> Dict[str, str]:
+        """Get headers for LinkedIn API requests"""
+        return {
+            'Authorization': f'Bearer {self.access_token}',
+            'Content-Type': 'application/json',
+            'X-Restli-Protocol-Version': '2.0.0'
+        }
+
+    def _markdown_to_plain_text(self, text: str) -> str:
+        """
+        Convert markdown to plain text suitable for LinkedIn.
+        Preserves basic formatting using unicode characters.
+        """
+        # Convert markdown bold to unicode bold (simplified - just remove markdown syntax)
+        # LinkedIn accepts plain text, so we'll keep it simple
+        text = re.sub(r'\*\*(.+?)\*\*', r'\1', text)  # Remove bold
+        text = re.sub(r'\*(.+?)\*', r'\1', text)  # Remove italic
+        text = re.sub(r'`(.+?)`', r'\1', text)  # Remove code formatting
+
+        # Convert markdown links [text](url) to "text (url)"
+        text = re.sub(r'\[(.+?)\]\((.+?)\)', r'\1 (\2)', text)
+
+        # Remove markdown headers
+        text = re.sub(r'^#+\s+', '', text, flags=re.MULTILINE)
+
+        return text.strip()
+
+    def _upload_image_to_linkedin(self, image_path: str) -> Optional[str]:
+        """
+        Upload an image to LinkedIn and return the asset URN.
+
+        Args:
+            image_path: Path to the image file
+
+        Returns:
+            Asset URN string or None if upload fails
+        """
+        try:
+            # Step 1: Register upload
+            register_upload_url = f"{self.linkedin_api_base}/v2/assets?action=registerUpload"
+
+            register_payload = {
+                "registerUploadRequest": {
+                    "recipes": ["urn:li:digitalmediaRecipe:feedshare-image"],
+                    "owner": self.author_id,
+                    "serviceRelationships": [
+                        {
+                            "relationshipType": "OWNER",
+                            "identifier": "urn:li:userGeneratedContent"
+                        }
+                    ]
+                }
+            }
+
+            response = requests.post(
+                register_upload_url,
+                headers=self._get_headers(),
+                json=register_payload
+            )
+            response.raise_for_status()
+
+            upload_data = response.json()
+            upload_url = upload_data['value']['uploadMechanism'][
+                'com.linkedin.digitalmedia.uploading.MediaUploadHttpRequest']['uploadUrl']
+            asset_urn = upload_data['value']['asset']
+
+            # Step 2: Upload the image binary
+            with open(image_path, 'rb') as image_file:
+                image_data = image_file.read()
+
+            upload_headers = {
+                'Authorization': f'Bearer {self.access_token}'
+            }
+
+            upload_response = requests.put(
+                upload_url,
+                headers=upload_headers,
+                data=image_data
+            )
+            upload_response.raise_for_status()
+
+            print(f"Image uploaded successfully: {asset_urn}")
+            return asset_urn
+
+        except requests.exceptions.RequestException as e:
+            print(f"Error uploading image to LinkedIn: {e}")
+            if hasattr(e.response, 'text'):
+                print(f"Response: {e.response.text}")
+            return None
+
+    def post_to_linkedin(
+        self,
+        text: str,
+        image_path: Optional[str] = None,
+        hashtags: Optional[List[str]] = None
+    ) -> Optional[str]:
+        """
+        Post content to LinkedIn.
+
+        Args:
+            text: Post content (markdown will be converted to plain text)
+            image_path: Optional path to image file
+            hashtags: Optional list of hashtags (without # symbol)
+
+        Returns:
+            LinkedIn post URL or None if posting fails
+        """
+        try:
+            # Convert markdown to plain text
+            plain_text = self._markdown_to_plain_text(text)
+
+            # Add hashtags at the end
+            if hashtags:
+                hashtag_string = ' '.join([f'#{tag}' for tag in hashtags])
+                plain_text = f"{plain_text}\n\n{hashtag_string}"
+
+            # Build the post payload
+            post_payload = {
+                "author": self.author_id,
+                "lifecycleState": "PUBLISHED",
+                "specificContent": {
+                    "com.linkedin.ugc.ShareContent": {
+                        "shareCommentary": {
+                            "text": plain_text
+                        },
+                        "shareMediaCategory": "NONE"
+                    }
+                },
+                "visibility": {
+                    "com.linkedin.ugc.MemberNetworkVisibility": "PUBLIC"
+                }
+            }
+
+            # Handle image upload if provided
+            if image_path and os.path.exists(image_path):
+                asset_urn = self._upload_image_to_linkedin(image_path)
+                if asset_urn:
+                    post_payload["specificContent"]["com.linkedin.ugc.ShareContent"].update({
+                        "shareMediaCategory": "IMAGE",
+                        "media": [
+                            {
+                                "status": "READY",
+                                "description": {
+                                    "text": "Post image"
+                                },
+                                "media": asset_urn,
+                                "title": {
+                                    "text": "Image"
+                                }
+                            }
+                        ]
+                    })
+
+            # Post to LinkedIn
+            response = requests.post(
+                self.linkedin_post_endpoint,
+                headers=self._get_headers(),
+                json=post_payload
+            )
+            response.raise_for_status()
+
+            # Extract post ID from response
+            post_id = response.headers.get('X-RestLi-Id', 'unknown')
+
+            print(f"Successfully posted to LinkedIn!")
+            print(f"Post ID: {post_id}")
+
+            # LinkedIn post URLs are not directly returned, but we can construct an approximate one
+            # Note: The actual URL may differ slightly
+            return f"https://www.linkedin.com/feed/update/{post_id}"
+
+        except requests.exceptions.RequestException as e:
+            print(f"Error posting to LinkedIn: {e}")
+            if hasattr(e.response, 'text'):
+                print(f"Response: {e.response.text}")
+            return None
+
+    def _remove_hashtags(self, text: str) -> str:
+        """Remove hashtags from text for Jekyll posts"""
+        # Remove hashtags (lines that are primarily hashtags)
+        lines = text.split('\n')
+        filtered_lines = []
+
+        for line in lines:
+            # Skip lines that are only hashtags
+            if line.strip() and not re.match(r'^[\s#\w]+$', line.strip()):
+                filtered_lines.append(line)
+            elif line.strip() and '#' not in line:
+                filtered_lines.append(line)
+
+        return '\n'.join(filtered_lines).strip()
+
+    def _copy_image_to_assets(self, image_path: str, post_slug: str) -> Optional[str]:
+        """
+        Copy image to Jekyll assets directory.
+
+        Args:
+            image_path: Source image path
+            post_slug: Slug for the post (used in image filename)
+
+        Returns:
+            Relative path to image from site root, or None if copy fails
+        """
+        try:
+            # Create assets directory if it doesn't exist
+            self.assets_dir.mkdir(parents=True, exist_ok=True)
+
+            # Get file extension
+            ext = Path(image_path).suffix
+
+            # Create new filename with date and slug
+            date_str = datetime.now().strftime('%Y-%m-%d')
+            new_filename = f"{date_str}-{post_slug}{ext}"
+            dest_path = self.assets_dir / new_filename
+
+            # Copy file
+            import shutil
+            shutil.copy2(image_path, dest_path)
+
+            # Return relative path from site root
+            relative_path = f"/assets/images/{new_filename}"
+            print(f"Image copied to: {dest_path}")
+
+            return relative_path
+
+        except Exception as e:
+            print(f"Error copying image: {e}")
+            return None
+
+    def create_jekyll_post(
+        self,
+        title: str,
+        content: str,
+        category: str,
+        image_path: Optional[str] = None
+    ) -> Optional[str]:
+        """
+        Create a Jekyll post file.
+
+        Args:
+            title: Post title
+            content: Post content in markdown
+            category: Category (e.g., 'data-science', 'software-engineering')
+            image_path: Optional path to post image
+
+        Returns:
+            Path to created post file, or None if creation fails
+        """
+        try:
+            # Create posts directory if it doesn't exist
+            self.posts_dir.mkdir(parents=True, exist_ok=True)
+
+            # Generate slug from title
+            slug = re.sub(r'[^\w\s-]', '', title.lower())
+            slug = re.sub(r'[-\s]+', '-', slug).strip('-')
+
+            # Generate filename with date
+            date_str = datetime.now().strftime('%Y-%m-%d')
+            filename = f"{date_str}-{slug}.md"
+            filepath = self.posts_dir / filename
+
+            # Remove hashtags from content
+            clean_content = self._remove_hashtags(content)
+
+            # Build frontmatter manually to preserve order
+            # Format: YYYY-MM-DD HH:MM:SS -0500 (Eastern Time)
+            date_formatted = datetime.now().strftime('%Y-%m-%d %H:%M:%S -0500')
+
+            # Start with required fields in the correct order
+            frontmatter_lines = [
+                '---',
+                'layout: post',
+                'author: lina',
+                f'title:  "{title}"',
+                f'date:   {date_formatted}',
+                f'categories: {category}'
+            ]
+
+            # Handle image if provided
+            if image_path and os.path.exists(image_path):
+                image_url = self._copy_image_to_assets(image_path, slug)
+                if image_url:
+                    frontmatter_lines.append(f'image: {image_url}')
+
+            frontmatter_lines.append('---')
+
+            # Combine frontmatter and content
+            full_content = '\n'.join(frontmatter_lines) + '\n\n' + clean_content
+
+            # Write to file
+            with open(filepath, 'w') as f:
+                f.write(full_content)
+
+            print(f"Jekyll post created: {filepath}")
+            return str(filepath)
+
+        except Exception as e:
+            print(f"Error creating Jekyll post: {e}")
+            return None
+
+    def cross_post(
+        self,
+        title: str,
+        content: str,
+        category: str,
+        image_path: Optional[str] = None,
+        hashtags: Optional[List[str]] = None,
+        linkedin_only: bool = False,
+        jekyll_only: bool = False
+    ) -> Tuple[Optional[str], Optional[str]]:
+        """
+        Post to both LinkedIn and Jekyll (or one platform only).
+
+        Args:
+            title: Post title
+            content: Post content
+            category: Jekyll category
+            image_path: Optional image path
+            hashtags: Optional list of hashtags for LinkedIn
+            linkedin_only: Only post to LinkedIn
+            jekyll_only: Only create Jekyll post
+
+        Returns:
+            Tuple of (linkedin_url, jekyll_path)
+        """
+        linkedin_url = None
+        jekyll_path = None
+
+        if not jekyll_only:
+            print("\n--- Posting to LinkedIn ---")
+            linkedin_url = self.post_to_linkedin(content, image_path, hashtags)
+
+            if linkedin_url:
+                print(f"LinkedIn URL: {linkedin_url}")
+            else:
+                print("LinkedIn posting failed!")
+
+        if not linkedin_only:
+            print("\n--- Creating Jekyll Post ---")
+            jekyll_path = self.create_jekyll_post(title, content, category, image_path)
+
+            if jekyll_path:
+                print(f"Jekyll post: {jekyll_path}")
+            else:
+                print("Jekyll post creation failed!")
+
+        return linkedin_url, jekyll_path
+
+
+def main():
+    """Main CLI entry point"""
+    parser = argparse.ArgumentParser(
+        description='Cross-post content to LinkedIn and Jekyll website'
+    )
+
+    # Content input options
+    content_group = parser.add_mutually_exclusive_group(required=True)
+    content_group.add_argument(
+        '--content',
+        help='Post content as string'
+    )
+    content_group.add_argument(
+        '--file',
+        help='Path to file containing post content (markdown)'
+    )
+
+    # Required arguments
+    parser.add_argument(
+        '--title',
+        required=True,
+        help='Post title'
+    )
+    parser.add_argument(
+        '--category',
+        required=True,
+        choices=['data-science', 'software-engineering', 'career', 'leadership'],
+        help='Post category for Jekyll'
+    )
+
+    # Optional arguments
+    parser.add_argument(
+        '--image',
+        help='Path to image file'
+    )
+    parser.add_argument(
+        '--hashtags',
+        nargs='+',
+        help='Hashtags for LinkedIn (without # symbol)'
+    )
+
+    # Platform selection
+    parser.add_argument(
+        '--linkedin-only',
+        action='store_true',
+        help='Only post to LinkedIn'
+    )
+    parser.add_argument(
+        '--jekyll-only',
+        action='store_true',
+        help='Only create Jekyll post'
+    )
+
+    args = parser.parse_args()
+
+    # Get content from file or string
+    if args.file:
+        try:
+            with open(args.file, 'r') as f:
+                content = f.read()
+        except Exception as e:
+            print(f"Error reading file: {e}")
+            sys.exit(1)
+    else:
+        content = args.content
+
+    # Validate image path if provided
+    if args.image and not os.path.exists(args.image):
+        print(f"Warning: Image file not found: {args.image}")
+        args.image = None
+
+    # Initialize cross-poster
+    # Only validate credentials if we need to post to LinkedIn
+    validate_creds = not args.jekyll_only
+    try:
+        poster = CrossPoster(validate_credentials=validate_creds)
+    except ValueError as e:
+        print(f"Error: {e}")
+        print("\nPlease ensure you have:")
+        print("1. Copied scripts/.env.example to scripts/.env")
+        print("2. Filled in your LinkedIn credentials in scripts/.env")
+        sys.exit(1)
+
+    # Perform cross-posting
+    print(f"\n{'='*60}")
+    print(f"Cross-Posting: {args.title}")
+    print(f"{'='*60}")
+
+    linkedin_url, jekyll_path = poster.cross_post(
+        title=args.title,
+        content=content,
+        category=args.category,
+        image_path=args.image,
+        hashtags=args.hashtags,
+        linkedin_only=args.linkedin_only,
+        jekyll_only=args.jekyll_only
+    )
+
+    # Summary
+    print(f"\n{'='*60}")
+    print("Summary:")
+    print(f"{'='*60}")
+
+    if linkedin_url:
+        print(f"LinkedIn: {linkedin_url}")
+    elif not args.jekyll_only:
+        print("LinkedIn: Failed")
+
+    if jekyll_path:
+        print(f"Jekyll: {jekyll_path}")
+    elif not args.linkedin_only:
+        print("Jekyll: Failed")
+
+    print(f"{'='*60}\n")
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/detect_author_id.py
+++ b/scripts/detect_author_id.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""
+Detect your LinkedIn Author ID using the w_member_social scope
+
+This script makes a test API call to discover your author URN.
+"""
+
+import sys
+import requests
+import json
+
+def detect_author_id(access_token):
+    """Try to detect the author ID using various LinkedIn API endpoints"""
+
+    print("="*60)
+    print("LinkedIn Author ID Detector")
+    print("="*60)
+
+    headers = {
+        'Authorization': f'Bearer {access_token}',
+        'Content-Type': 'application/json',
+        'X-Restli-Protocol-Version': '2.0.0'
+    }
+
+    # Method 1: Try to get profile info (may fail with 403)
+    print("\nAttempting Method 1: Profile API...")
+    try:
+        response = requests.get('https://api.linkedin.com/v2/me', headers=headers)
+        if response.status_code == 200:
+            data = response.json()
+            person_id = data.get('id')
+            if person_id:
+                author_urn = f"urn:li:person:{person_id}"
+                print_success(author_urn, data)
+                return author_urn
+        else:
+            print(f"  Status: {response.status_code} - {response.text[:100]}")
+    except Exception as e:
+        print(f"  Failed: {e}")
+
+    # Method 2: Introspect the token itself
+    print("\nAttempting Method 2: Token Introspection...")
+    print("  (This will tell us what user the token belongs to)")
+
+    # LinkedIn doesn't have a standard introspection endpoint, but we can try
+    # to make a minimal UGC post request that will fail but reveal the author
+
+    print("\nAttempting Method 3: Make a test UGC share request...")
+    print("  (We'll use an invalid format that won't actually post)")
+
+    test_payload = {
+        "author": "urn:li:person:UNKNOWN",
+        "lifecycleState": "PUBLISHED",
+        "specificContent": {
+            "com.linkedin.ugc.ShareContent": {
+                "shareCommentary": {
+                    "text": "Test"
+                },
+                "shareMediaCategory": "NONE"
+            }
+        },
+        "visibility": {
+            "com.linkedin.ugc.MemberNetworkVisibility": "PUBLIC"
+        }
+    }
+
+    try:
+        response = requests.post(
+            'https://api.linkedin.com/v2/ugcPosts',
+            headers=headers,
+            json=test_payload
+        )
+
+        print(f"  Status: {response.status_code}")
+        print(f"  Response: {response.text[:500]}")
+
+        # The error might contain info about the correct author ID
+        if 'author' in response.text.lower():
+            print("\n  The error message might contain clues about your author ID.")
+            print("  Look for any URN format like 'urn:li:person:XXXXX'")
+
+    except Exception as e:
+        print(f"  Failed: {e}")
+
+    # Method 4: Check if we can get it from userinfo (OpenID)
+    print("\nAttempting Method 4: OpenID UserInfo endpoint...")
+    try:
+        response = requests.get('https://api.linkedin.com/v2/userinfo', headers=headers)
+        if response.status_code == 200:
+            data = response.json()
+            person_id = data.get('sub')
+            if person_id:
+                author_urn = f"urn:li:person:{person_id}"
+                print_success(author_urn, data)
+                return author_urn
+        else:
+            print(f"  Status: {response.status_code}")
+    except Exception as e:
+        print(f"  Failed: {e}")
+
+    print("\n" + "="*60)
+    print("UNABLE TO AUTO-DETECT AUTHOR ID")
+    print("="*60)
+    print("\nUnfortunately, the w_member_social scope alone doesn't provide")
+    print("access to your profile information.")
+    print("\n" + "="*60)
+    print("NEXT STEPS:")
+    print("="*60)
+    print("\n1. Try reaching out to LinkedIn Developer Support")
+    print("2. Look in your LinkedIn profile URL")
+    print("   Example: linkedin.com/in/USERNAME")
+    print("\n3. OR: Create a test post manually and inspect it:")
+    print("   - Make a post on LinkedIn")
+    print("   - Use browser dev tools to inspect the API call")
+    print("   - Look for 'urn:li:person:XXXXX' in the request")
+    print("\n" + "="*60 + "\n")
+
+    return None
+
+def print_success(author_urn, data=None):
+    """Print success message with author URN"""
+    print("\n" + "="*60)
+    print("✅ SUCCESS!")
+    print("="*60)
+    print(f"\nYour LinkedIn Author ID is:")
+    print(f"\n  {author_urn}")
+    print(f"\nAdd this to your scripts/.env file:")
+    print(f"\n  LINKEDIN_AUTHOR_ID={author_urn}")
+    print("\n" + "="*60)
+
+    if data:
+        print("\nProfile information:")
+        for key, value in data.items():
+            if key not in ['id', 'sub']:
+                print(f"  {key}: {value}")
+
+    print("="*60 + "\n")
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python detect_author_id.py YOUR_ACCESS_TOKEN")
+        print("\nExample:")
+        print("  python detect_author_id.py AQVEg9hyftCm...")
+        sys.exit(1)
+
+    access_token = sys.argv[1]
+
+    if len(access_token) < 20:
+        print("Error: Access token appears invalid (too short)")
+        sys.exit(1)
+
+    detect_author_id(access_token)
+
+if __name__ == '__main__':
+    main()

--- a/scripts/example-post.md
+++ b/scripts/example-post.md
@@ -1,0 +1,23 @@
+# Example Post Content
+
+This is an example markdown file showing how to format your content for cross-posting.
+
+## Introduction
+
+You can use **bold text**, *italic text*, and even `code snippets` in your markdown.
+
+## Key Points
+
+Here are some important insights:
+
+- Data science is evolving rapidly
+- Machine learning models require careful validation
+- Always document your methodology
+
+## Links and References
+
+You can include [links like this](https://example.com) and they'll be properly formatted for each platform.
+
+## Conclusion
+
+This content will be automatically converted to the right format for LinkedIn (plain text with hashtags) and Jekyll (clean markdown without hashtags).

--- a/scripts/find_author_id.py
+++ b/scripts/find_author_id.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+Find your LinkedIn Author ID by inspecting your LinkedIn profile URL
+
+This script helps you find your LinkedIn person URN without needing
+additional API scopes beyond w_member_social.
+"""
+
+import sys
+
+def main():
+    print("="*60)
+    print("LinkedIn Author ID Finder")
+    print("="*60)
+    print("\nSince the w_member_social scope doesn't provide access to")
+    print("profile endpoints, we'll use your LinkedIn profile URL instead.")
+    print("\n" + "="*60)
+    print("OPTION 1: Extract from Public Profile")
+    print("="*60)
+    print("\n1. Go to your LinkedIn profile page")
+    print("2. Look at the URL in your browser")
+    print("3. It should look like: https://www.linkedin.com/in/USERNAME/")
+    print("4. Note your USERNAME")
+    print("\nFor example, if your URL is:")
+    print("  https://www.linkedin.com/in/linafaller/")
+    print("Your username is: linafaller")
+
+    print("\n" + "="*60)
+    print("OPTION 2: Use LinkedIn Inspector Tool")
+    print("="*60)
+    print("\n1. Go to: https://www.linkedin.com/help/linkedin/answer/a519819")
+    print("2. This shows tools to inspect your LinkedIn profile")
+    print("3. Look for your 'Member ID' or 'URN'")
+
+    print("\n" + "="*60)
+    print("OPTION 3: Test Post Method (Recommended)")
+    print("="*60)
+    print("\nThe easiest way is to make a test post and capture the author")
+    print("information from the API response.")
+    print("\nLet's do that now!")
+    print("\n" + "="*60)
+
+    # Get access token
+    if len(sys.argv) > 1:
+        access_token = sys.argv[1]
+    else:
+        print("\nPlease paste your LinkedIn access token:")
+        access_token = input("> ").strip()
+
+    if not access_token or len(access_token) < 10:
+        print("Error: Invalid access token")
+        sys.exit(1)
+
+    print("\nI'll now make a test API call to discover your author ID...")
+    print("Note: This will create a DRAFT post (not published) to safely get your ID")
+
+    import requests
+
+    # We'll try to make a minimal test call that reveals the author
+    # The ugcPosts endpoint returns the author info we need
+
+    url = "https://api.linkedin.com/v2/me"
+    headers = {
+        'Authorization': f'Bearer {access_token}',
+        'X-Restli-Protocol-Version': '2.0.0'
+    }
+
+    # First try: Check what info we can get with current token
+    print("\nChecking your token permissions...")
+
+    response = requests.get(url, headers=headers)
+
+    if response.status_code == 200:
+        data = response.json()
+        person_id = data.get('id')
+        if person_id:
+            author_urn = f"urn:li:person:{person_id}"
+            print("\n" + "="*60)
+            print("SUCCESS!")
+            print("="*60)
+            print(f"\nYour LinkedIn Author ID is:")
+            print(f"\n  {author_urn}")
+            print(f"\nAdd this to your scripts/.env file:")
+            print(f"\n  LINKEDIN_AUTHOR_ID={author_urn}")
+            print("\n" + "="*60 + "\n")
+            return
+
+    # If that didn't work, provide manual instructions
+    print("\n" + "="*60)
+    print("Manual Method Required")
+    print("="*60)
+    print("\nPlease visit your LinkedIn profile and provide your profile URL")
+    print("or username so we can construct your author URN.")
+    print("\nWhat is your LinkedIn profile URL or username?")
+    profile_input = input("> ").strip()
+
+    # Extract username from URL if provided
+    if 'linkedin.com' in profile_input:
+        parts = profile_input.split('/in/')
+        if len(parts) > 1:
+            username = parts[1].strip('/').split('/')[0]
+        else:
+            print("Couldn't parse URL. Please provide just your username.")
+            username = input("Username: ").strip()
+    else:
+        username = profile_input
+
+    print(f"\nYour username: {username}")
+    print("\nUnfortunately, we need the numeric person ID, not just the username.")
+    print("LinkedIn doesn't provide a public API to convert username to person ID")
+    print("without additional API scopes.")
+    print("\n" + "="*60)
+    print("RECOMMENDED SOLUTION:")
+    print("="*60)
+    print("\n1. Go back to LinkedIn Developer Portal")
+    print("2. Regenerate your OAuth token with BOTH scopes:")
+    print("   - w_member_social (for posting)")
+    print("   - r_liteprofile OR r_basicprofile (for getting your ID)")
+    print("3. Run this script again with the new token")
+    print("\nOR")
+    print("\n4. Contact me with your username and I'll help find your person ID")
+    print("="*60 + "\n")
+
+if __name__ == '__main__':
+    main()

--- a/scripts/get_author_id.py
+++ b/scripts/get_author_id.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""
+Helper script to get your LinkedIn Author ID
+
+Usage:
+    python get_author_id.py YOUR_ACCESS_TOKEN
+
+This will fetch your LinkedIn profile information and display your author ID
+in the format needed for the .env file.
+"""
+
+import sys
+import requests
+
+def get_author_id(access_token):
+    """Fetch LinkedIn author ID using the access token"""
+
+    # Method 1: Try userinfo endpoint (requires r_liteprofile or r_basicprofile)
+    print("Attempting to fetch your LinkedIn author ID...")
+    print("\nMethod 1: Trying v2/userinfo endpoint...")
+
+    url = "https://api.linkedin.com/v2/userinfo"
+    headers = {
+        'Authorization': f'Bearer {access_token}'
+    }
+
+    try:
+        response = requests.get(url, headers=headers)
+
+        if response.status_code == 200:
+            data = response.json()
+            person_id = data.get('sub')
+
+            if person_id:
+                author_urn = f"urn:li:person:{person_id}"
+                print("\n" + "="*60)
+                print("SUCCESS!")
+                print("="*60)
+                print(f"\nYour LinkedIn Author ID is:")
+                print(f"\n  {author_urn}")
+                print(f"\nAdd this to your scripts/.env file:")
+                print(f"\n  LINKEDIN_AUTHOR_ID={author_urn}")
+                print("\n" + "="*60)
+
+                name = data.get('name', 'N/A')
+                email = data.get('email', 'N/A')
+                print(f"\nProfile verification:")
+                print(f"  Name: {name}")
+                print(f"  Email: {email}")
+                print("="*60 + "\n")
+                return author_urn
+    except:
+        pass
+
+    # Method 2: Try v2/me endpoint
+    print("Method 1 failed. Trying v2/me endpoint...")
+    url = "https://api.linkedin.com/v2/me"
+
+    try:
+        response = requests.get(url, headers=headers)
+
+        if response.status_code == 200:
+            data = response.json()
+            person_id = data.get('id')
+
+            if person_id:
+                author_urn = f"urn:li:person:{person_id}"
+                print("\n" + "="*60)
+                print("SUCCESS!")
+                print("="*60)
+                print(f"\nYour LinkedIn Author ID is:")
+                print(f"\n  {author_urn}")
+                print(f"\nAdd this to your scripts/.env file:")
+                print(f"\n  LINKEDIN_AUTHOR_ID={author_urn}")
+                print("\n" + "="*60 + "\n")
+                return author_urn
+    except:
+        pass
+
+    # If both methods failed
+    print("\n" + "="*60)
+    print("UNABLE TO FETCH AUTHOR ID AUTOMATICALLY")
+    print("="*60)
+    print("\nThe w_member_social scope alone is not sufficient to fetch")
+    print("your profile information via the API.")
+    print("\n" + "="*60)
+    print("MANUAL SOLUTION:")
+    print("="*60)
+    print("\n1. Make a test post using the API to find your author ID")
+    print("2. We'll extract it from the response")
+    print("\nWould you like to run the test post? (This will post publicly)")
+    print("We can make a simple test post and then delete it.")
+    print("\nAlternatively, you can:")
+    print("  - Add 'r_liteprofile' scope to your OAuth token")
+    print("  - Or manually find your person ID from LinkedIn's API")
+    print("="*60 + "\n")
+
+    return None
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: python get_author_id.py YOUR_ACCESS_TOKEN")
+        print("\nExample:")
+        print("  python get_author_id.py AQVBl9p...")
+        print("\nTo get an access token:")
+        print("  1. Go to LinkedIn Developer Portal")
+        print("  2. Select your app")
+        print("  3. Use the OAuth 2.0 tools to generate a token with 'w_member_social' scope")
+        sys.exit(1)
+
+    access_token = sys.argv[1]
+
+    if not access_token or len(access_token) < 10:
+        print("Error: Access token appears to be invalid (too short)")
+        sys.exit(1)
+
+    get_author_id(access_token)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/linkedin_post.py
+++ b/scripts/linkedin_post.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""
+LinkedIn-only posting script for GitHub Actions
+
+This script reads a Jekyll markdown post and posts it to LinkedIn.
+"""
+
+import sys
+import os
+import re
+import requests
+from pathlib import Path
+from dotenv import load_dotenv
+
+def extract_frontmatter_and_content(file_path):
+    """Extract frontmatter and content from a Jekyll markdown file"""
+    with open(file_path, 'r', encoding='utf-8') as f:
+        content = f.read()
+
+    # Split frontmatter and content
+    parts = content.split('---', 2)
+    if len(parts) < 3:
+        raise ValueError("Invalid markdown file: missing frontmatter")
+
+    frontmatter = parts[1].strip()
+    body = parts[2].strip()
+
+    # Parse frontmatter
+    metadata = {}
+    for line in frontmatter.split('\n'):
+        if ':' in line:
+            key, value = line.split(':', 1)
+            metadata[key.strip()] = value.strip().strip('"')
+
+    return metadata, body
+
+def markdown_to_linkedin(content):
+    """Convert markdown to LinkedIn-friendly plain text"""
+    # Remove HTML comments
+    content = re.sub(r'<!--.*?-->', '', content, flags=re.DOTALL)
+
+    # Convert bold (**text** or __text__)
+    content = re.sub(r'\*\*(.+?)\*\*', r'*\1*', content)
+    content = re.sub(r'__(.+?)__', r'*\1*', content)
+
+    # Convert italic (*text* or _text_)
+    content = re.sub(r'(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)', r'\1', content)
+    content = re.sub(r'_(.+?)_', r'\1', content)
+
+    # Convert inline code (`code`)
+    content = re.sub(r'`([^`]+)`', r'\1', content)
+
+    # Convert links [text](url) to just the URL
+    content = re.sub(r'\[([^\]]+)\]\(([^\)]+)\)', r'\2', content)
+
+    # Convert headers (## Header) to just text
+    content = re.sub(r'^#{1,6}\s+(.+)$', r'\1', content, flags=re.MULTILINE)
+
+    # Clean up bullet points
+    content = re.sub(r'^\s*[-*+]\s+', '• ', content, flags=re.MULTILINE)
+
+    # Remove extra blank lines
+    content = re.sub(r'\n{3,}', '\n\n', content)
+
+    return content.strip()
+
+def extract_category_hashtags(categories):
+    """Convert categories to hashtags"""
+    if not categories:
+        return []
+
+    # Split by comma or space
+    cat_list = re.split(r'[,\s]+', categories)
+
+    # Convert to hashtags
+    hashtags = []
+    for cat in cat_list:
+        cat = cat.strip()
+        if cat:
+            # Remove hyphens and make camelCase
+            words = cat.split('-')
+            hashtag = ''.join(word.capitalize() for word in words)
+            hashtags.append(f'#{hashtag}')
+
+    return hashtags
+
+def post_to_linkedin(author_id, access_token, text):
+    """Post text content to LinkedIn"""
+    url = "https://api.linkedin.com/v2/ugcPosts"
+
+    headers = {
+        'Authorization': f'Bearer {access_token}',
+        'Content-Type': 'application/json',
+        'X-Restli-Protocol-Version': '2.0.0'
+    }
+
+    payload = {
+        "author": author_id,
+        "lifecycleState": "PUBLISHED",
+        "specificContent": {
+            "com.linkedin.ugc.ShareContent": {
+                "shareCommentary": {
+                    "text": text
+                },
+                "shareMediaCategory": "NONE"
+            }
+        },
+        "visibility": {
+            "com.linkedin.ugc.MemberNetworkVisibility": "PUBLIC"
+        }
+    }
+
+    response = requests.post(url, headers=headers, json=payload)
+
+    if response.status_code == 201:
+        return True, "Post published successfully!"
+    else:
+        return False, f"Error {response.status_code}: {response.text}"
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python linkedin_post.py POST_FILE.md")
+        sys.exit(1)
+
+    post_file = sys.argv[1]
+
+    # Load environment variables
+    load_dotenv()
+    access_token = os.getenv('LINKEDIN_ACCESS_TOKEN')
+    author_id = os.getenv('LINKEDIN_AUTHOR_ID')
+
+    if not access_token or not author_id:
+        print("Error: Missing LinkedIn credentials in environment variables")
+        print("Required: LINKEDIN_ACCESS_TOKEN and LINKEDIN_AUTHOR_ID")
+        sys.exit(1)
+
+    # Extract post content
+    print(f"Reading post: {post_file}")
+    metadata, content = extract_frontmatter_and_content(post_file)
+
+    title = metadata.get('title', 'Untitled')
+    categories = metadata.get('categories', '')
+
+    print(f"Title: {title}")
+    print(f"Categories: {categories}")
+
+    # Convert to LinkedIn format
+    linkedin_text = markdown_to_linkedin(content)
+
+    # Add hashtags
+    hashtags = extract_category_hashtags(categories)
+    if hashtags:
+        linkedin_text += "\n\n" + " ".join(hashtags)
+
+    print(f"\nLinkedIn post preview:")
+    print("-" * 60)
+    print(linkedin_text)
+    print("-" * 60)
+
+    # Post to LinkedIn
+    print("\nPosting to LinkedIn...")
+    success, message = post_to_linkedin(author_id, access_token, linkedin_text)
+
+    if success:
+        print(f"✓ {message}")
+    else:
+        print(f"✗ {message}")
+        sys.exit(1)
+
+if __name__ == '__main__':
+    main()

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,14 @@
+# LinkedIn Jekyll Cross-Posting Automation
+# Python dependencies
+
+# LinkedIn API calls
+requests>=2.31.0
+
+# Environment variable management
+python-dotenv>=1.0.0
+
+# Markdown processing
+markdown>=3.5.0
+
+# Image processing (optional, for resizing/optimization)
+Pillow>=10.0.0

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Setup script for LinkedIn-Jekyll Cross-Posting Automation
+
+echo "Setting up LinkedIn-Jekyll Cross-Posting Automation..."
+
+# Create virtual environment
+echo "Creating virtual environment..."
+python3 -m venv venv
+
+# Activate virtual environment
+echo "Activating virtual environment..."
+source venv/bin/activate
+
+# Upgrade pip
+echo "Upgrading pip..."
+pip install --upgrade pip
+
+# Install requirements
+echo "Installing dependencies..."
+pip install -r requirements.txt
+
+echo ""
+echo "✅ Setup complete!"
+echo ""
+echo "To use the cross-poster:"
+echo "  1. Activate the virtual environment:"
+echo "     source venv/bin/activate"
+echo ""
+echo "  2. Copy and configure your credentials:"
+echo "     cp .env.example .env"
+echo "     # Then edit .env with your LinkedIn credentials"
+echo ""
+echo "  3. Run the cross-poster:"
+echo "     python cross_poster.py --help"
+echo ""
+echo "To deactivate the virtual environment when done:"
+echo "  deactivate"
+echo ""

--- a/scripts/test_linkedin_post.py
+++ b/scripts/test_linkedin_post.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""
+Test LinkedIn posting and extract member ID from error response
+
+This script attempts to post with different URN formats to discover
+the correct member ID format that LinkedIn expects.
+"""
+
+import sys
+import requests
+import json
+import os
+from dotenv import load_dotenv
+
+def test_post_with_urn(access_token, author_urn):
+    """Attempt to post with a given URN and analyze the response"""
+
+    url = "https://api.linkedin.com/v2/ugcPosts"
+    headers = {
+        'Authorization': f'Bearer {access_token}',
+        'Content-Type': 'application/json',
+        'X-Restli-Protocol-Version': '2.0.0'
+    }
+
+    payload = {
+        "author": author_urn,
+        "lifecycleState": "PUBLISHED",
+        "specificContent": {
+            "com.linkedin.ugc.ShareContent": {
+                "shareCommentary": {
+                    "text": "Test post - please ignore (will delete shortly)"
+                },
+                "shareMediaCategory": "NONE"
+            }
+        },
+        "visibility": {
+            "com.linkedin.ugc.MemberNetworkVisibility": "PUBLIC"
+        }
+    }
+
+    print(f"\nTesting with URN: {author_urn}")
+    print("-" * 60)
+
+    response = requests.post(url, headers=headers, json=payload)
+
+    print(f"Status Code: {response.status_code}")
+    print(f"Response: {response.text}")
+
+    return response
+
+def main():
+    # Load environment variables
+    load_dotenv('/Users/linafaller/repos/lfaller.github.io/scripts/.env')
+
+    access_token = os.getenv('LINKEDIN_ACCESS_TOKEN')
+    author_id = os.getenv('LINKEDIN_AUTHOR_ID')
+
+    if not access_token:
+        print("Error: LINKEDIN_ACCESS_TOKEN not found in .env file")
+        sys.exit(1)
+
+    print("=" * 60)
+    print("LinkedIn Member ID Finder")
+    print("=" * 60)
+    print("\nThis script will attempt different URN formats to find")
+    print("the correct member ID.\n")
+
+    # Try the current author ID from .env
+    if author_id:
+        print(f"Found LINKEDIN_AUTHOR_ID in .env: {author_id}")
+        test_post_with_urn(access_token, author_id)
+
+    # Try converting to member URN
+    if author_id and 'ACoAAAERPDoBimyT2I0gXmYOPhXW7D7jDTpnNCY' in author_id:
+        print("\n" + "=" * 60)
+        print("Trying with urn:li:member format...")
+        print("=" * 60)
+        member_urn = "urn:li:member:ACoAAAERPDoBimyT2I0gXmYOPhXW7D7jDTpnNCY"
+        test_post_with_urn(access_token, member_urn)
+
+    # Check token scopes
+    print("\n" + "=" * 60)
+    print("Checking Token Scopes")
+    print("=" * 60)
+
+    # Try to introspect token (if LinkedIn supports it)
+    introspect_url = "https://api.linkedin.com/oauth/v2/introspectToken"
+    headers = {
+        'Authorization': f'Bearer {access_token}'
+    }
+
+    response = requests.get(introspect_url, headers=headers)
+    print(f"\nToken introspection status: {response.status_code}")
+    if response.status_code == 200:
+        print(f"Response: {json.dumps(response.json(), indent=2)}")
+    else:
+        print(f"Response: {response.text}")
+
+    print("\n" + "=" * 60)
+    print("RECOMMENDATION")
+    print("=" * 60)
+    print("\nIf all attempts failed with 403 or 422 errors:")
+    print("\n1. Verify your OAuth token was generated with these scopes:")
+    print("   - openid")
+    print("   - profile")
+    print("   - w_member_social")
+    print("\n2. The token might need to be regenerated after adding")
+    print("   the OpenID Connect product to your app")
+    print("\n3. After regenerating, try this endpoint directly:")
+    print("   curl -H 'Authorization: Bearer YOUR_TOKEN' \\")
+    print("        https://api.linkedin.com/v2/userinfo")
+    print("=" * 60 + "\n")
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Implements automated cross-posting system that posts to LinkedIn when new content is pushed to the repository.

Features:
- GitHub Actions workflow for automatic LinkedIn posting
- Python scripts for markdown-to-LinkedIn conversion
- Helper scripts for LinkedIn API credential setup
- Manual posting mode via CLI
- Comprehensive documentation for setup and troubleshooting

Components:
- .github/workflows/linkedin-crosspost.yml: Auto-posts on push to main
- scripts/linkedin_post.py: Standalone LinkedIn posting script
- scripts/cross_poster.py: Full-featured cross-poster (manual mode)
- scripts/get_author_id.py: Helper to retrieve LinkedIn member ID
- scripts/LINKEDIN_SETUP.md: Complete API setup documentation

LinkedIn API Notes:
- Requires 'openid', 'profile', and 'w_member_social' scopes
- Must use numeric member URN format (urn:li:member:123456)
- Access tokens expire after 60 days
- Authorization changes may take a few minutes to propagate

The automated workflow allows posting by simply committing markdown files to _posts/ directory - GitHub Actions handles the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)